### PR TITLE
Added Several ArrayJob Methods to the PBS Class

### DIFF
--- a/src/main/java/com/tupilabs/pbs/PBS.java
+++ b/src/main/java/com/tupilabs/pbs/PBS.java
@@ -349,6 +349,47 @@ public class PBS {
         return jobId.trim();
     }
     
+/**
+     * PBS qsub command with arguments resource overrides 
+     * <p>
+     * Equivalent to qsub [param] -l [resource_name=value,resource_name=value]]
+     * @param input job input file
+     * @param variable number of resources to override
+     * @return job id
+     */
+    public static String qsub(String input, String... resourceOverrides) {
+    	final CommandLine cmdLine = new CommandLine(COMMAND_QSUB);
+    	cmdLine.addArgument(PARAMETER_RESOURCE_OVERRIDE_STATUS);
+    	String resourceOverrideArgument = StringUtils.join(resourceOverrides, ",");
+    	cmdLine.addArgument(resourceOverrideArgument);
+        cmdLine.addArgument(input);
+        
+        final OutputStream out = new ByteArrayOutputStream();
+        final OutputStream err = new ByteArrayOutputStream();
+        
+        DefaultExecuteResultHandler resultHandler;
+        try {
+            resultHandler = execute(cmdLine, out, err);
+            resultHandler.waitFor(DEFAULT_TIMEOUT);
+        } catch (ExecuteException e) {
+            throw new PBSException("Failed to execute qsub command: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new PBSException("Failed to execute qsub command: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            throw new PBSException("Failed to execute qsub command: " + e.getMessage(), e);
+        }
+        
+        final int exitValue = resultHandler.getExitValue();
+        LOGGER.info("qsub exit value: " + exitValue);
+        LOGGER.fine("qsub output: " + out.toString());
+        
+        if (exitValue != 0)
+        	throw new PBSException("Failed to submit job script " + input + ". Error output: " + err.toString());
+        
+        String jobId = out.toString();
+        return jobId.trim();
+    }
+
     /**
      * PBS qsub command for an Array Job with Specific PBS_ARRAY_IDs to submit 
      * <p>
@@ -362,6 +403,51 @@ public class PBS {
     	cmdLine.addArgument(PARAMETER_ARRAY_JOB_STATUS);
     	String listArgument = StringUtils.join(pbsArrayIDs, ",");
     	cmdLine.addArgument(listArgument);
+        cmdLine.addArgument(input);
+        
+        final OutputStream out = new ByteArrayOutputStream();
+        final OutputStream err = new ByteArrayOutputStream();
+        
+        DefaultExecuteResultHandler resultHandler;
+        try {
+            resultHandler = execute(cmdLine, out, err);
+            resultHandler.waitFor(DEFAULT_TIMEOUT);
+        } catch (ExecuteException e) {
+            throw new PBSException("Failed to execute qsub command: " + e.getMessage(), e);
+        } catch (IOException e) {
+            throw new PBSException("Failed to execute qsub command: " + e.getMessage(), e);
+        } catch (InterruptedException e) {
+            throw new PBSException("Failed to execute qsub command: " + e.getMessage(), e);
+        }
+        
+        final int exitValue = resultHandler.getExitValue();
+        LOGGER.info("qsub exit value: " + exitValue);
+        LOGGER.fine("qsub output: " + out.toString());
+        
+        if (exitValue != 0)
+        	throw new PBSException("Failed to submit job script " + input + ". Error output: " + err.toString());
+        
+        String jobId = out.toString();
+        return jobId.trim();
+    }
+    
+    /**
+     * PBS qsub command for an Array Job with Specific PBS_ARRAY_IDs to submit, and resource overrides
+     * <p>
+     * Equivalent to qsub -t 1,2,3 -l [resource_name=value,resource_name=value] [param]
+     * @param input job input file
+     * @param list of specified PBS indices
+     * @param list of resource overrides
+     * @return job id of array job
+     */
+    public static String qsubArrayJob(String input, List<Integer> pbsArrayIDs, String... resourceOverrides) {
+    	final CommandLine cmdLine = new CommandLine(COMMAND_QSUB);
+    	cmdLine.addArgument(PARAMETER_ARRAY_JOB_STATUS);
+    	String listArgument = StringUtils.join(pbsArrayIDs, ",");
+    	cmdLine.addArgument(listArgument);
+    	cmdLine.addArgument(PARAMETER_RESOURCE_OVERRIDE_STATUS);
+    	String resourceOverrideArgument = StringUtils.join(resourceOverrides, ",");
+    	cmdLine.addArgument(resourceOverrideArgument);
         cmdLine.addArgument(input);
         
         final OutputStream out = new ByteArrayOutputStream();
@@ -549,6 +635,7 @@ public class PBS {
     private static final String PARAMETER_XML = "-x";
     private static final String PARAMETER_FULL_STATUS = "-f";
     private static final String PARAMETER_ARRAY_JOB_STATUS = "-t";
+    private static final String PARAMETER_RESOURCE_OVERRIDE_STATUS = "-l";
     private static final String PARAMETER_QUEUE = "-Q";
     // tracejob
     private static final String PARAMETER_NUMBER_OF_DAYS = "-n";

--- a/src/main/java/com/tupilabs/pbs/parser/QstatJobsParser.java
+++ b/src/main/java/com/tupilabs/pbs/parser/QstatJobsParser.java
@@ -85,68 +85,68 @@ public class QstatJobsParser implements Parser<String, List<Job>> {
                     if(temp.length == 2) {
                         final String key = temp[0].trim().toLowerCase();
                         final String value = temp[1].trim();
-                        if("job_name".equals(key)) {
+                        if("job_name".equalsIgnoreCase(key)) {
                             job.setName(value);
-                        } else if("job_owner".equals(key)) {
+                        } else if("job_owner".equalsIgnoreCase(key)) {
                             job.setOwner(value);
                         } else if(key.startsWith("resources_used.")) {
                             job.getResourcesUsed().put(key, value);
-                        } else if("job_state".equals(key)) {
+                        } else if("job_state".equalsIgnoreCase(key)) {
                             job.setState(value);
-                        } else if("queue".equals(key)) {
+                        } else if("queue".equalsIgnoreCase(key)) {
                             job.setQueue(value);
-                        } else if("server".equals(key)) {
+                        } else if("server".equalsIgnoreCase(key)) {
                             job.setServer(value);
-                        } else if("checkpoint".equals(key)) {
+                        } else if("checkpoint".equalsIgnoreCase(key)) {
                             job.setCheckpoint(value);
-                        } else if("ctime".equals(key)) {
+                        } else if("ctime".equalsIgnoreCase(key)) {
                             job.setCtime(value);
-                        } else if("error_path".equals(key)) {
+                        } else if("error_path".equalsIgnoreCase(key)) {
                             job.setErrorPath(value);
-                        } else if("exec_host".equals(key)) {
+                        } else if("exec_host".equalsIgnoreCase(key)) {
                             job.setExecHost(value);
-                        } else if("exec_port".equals(key)) {
+                        } else if("exec_port".equalsIgnoreCase(key)) {
                             try {
                                 job.setExecPort(Integer.parseInt(value));
                             } catch (NumberFormatException nfe) {
                                 LOGGER.log(Level.WARNING, "Failed parsing job exec port: " + nfe.getMessage(), nfe);
                                 job.setExecPort(-1);
                             }
-                        } else if("hold_types".equals(key)) {
+                        } else if("hold_types".equalsIgnoreCase(key)) {
                             job.setHoldTypes(value);
-                        } else if("join_path".equals(key)) {
+                        } else if("join_path".equalsIgnoreCase(key)) {
                             job.setJoinPath(value);
-                        } else if("keep_files".equals(key)) {
+                        } else if("keep_files".equalsIgnoreCase(key)) {
                             job.setKeepFiles(value);
-                        } else if("mail_points".equals(key)) {
+                        } else if("mail_points".equalsIgnoreCase(key)) {
                             job.setMailPoints(value);
-                        } else if("mail_users".equals(key)) {
+                        } else if("mail_users".equalsIgnoreCase(key)) {
                             job.setMailUsers(value);
-                        } else if("mtime".equals(key)) {
+                        } else if("mtime".equalsIgnoreCase(key)) {
                             job.setMtime(value);
-                        } else if("output_path".equals(key)) {
+                        } else if("output_path".equalsIgnoreCase(key)) {
                             job.setOutputPath(value);
-                        } else if("priority".equals(key)) {
+                        } else if("priority".equalsIgnoreCase(key)) {
                             try {
                                 job.setPriority(Integer.parseInt(value));
                             } catch (NumberFormatException nfe) {
                                 LOGGER.log(Level.WARNING, "Failed parsing job priority: " + nfe.getMessage(), nfe);
                                 job.setPriority(-1);
                             }
-                        } else if("qtime".equals(key)) {
+                        } else if("qtime".equalsIgnoreCase(key)) {
                             job.setQtime(value);
-                        } else if("rerunable".equals(key)) {
+                        } else if("rerunable".equalsIgnoreCase(key)) {
                             job.setRerunable(Boolean.parseBoolean(value));
                         } else if(key.startsWith("resource_list.")) {
                             job.getResourceList().put(key, value);
-                        } else if("session_id".equals(key)) {
+                        } else if("session_id".equalsIgnoreCase(key)) {
                             try {
                                 job.setSessionId(Integer.parseInt(value));
                             } catch (NumberFormatException nfe) {
                                 LOGGER.log(Level.WARNING, "Failed parsing job session id: " + nfe.getMessage(), nfe);
                                 job.setSessionId(-1);
                             }
-                        } else if("substate".equals(key)) {
+                        } else if("substate".equalsIgnoreCase(key)) {
                             try {
                                 job.setSubstate(Integer.parseInt(value));
                             } catch (NumberFormatException nfe) {
@@ -155,48 +155,48 @@ public class QstatJobsParser implements Parser<String, List<Job>> {
                             }
                         } else if(key.startsWith("variable_list")) {
                            job.getVariableList().put(key, value);
-                        } else if("etime".equals(key)) {
+                        } else if("etime".equalsIgnoreCase(key)) {
                             job.setEtime(value);
-                        } else if("euser".equals(key)) {
+                        } else if("euser".equalsIgnoreCase(key)) {
                             job.setEuser(value);
-                        } else if("egroup".equals(key)) {
+                        } else if("egroup".equalsIgnoreCase(key)) {
                             job.setEgroup(value);
-                        } else if("hashname".equals(key)) {
+                        } else if("hashname".equalsIgnoreCase(key)) {
                             job.setHashName(value);
-                        } else if("queue_rank".equals(key)) {
+                        } else if("queue_rank".equalsIgnoreCase(key)) {
                             try {
                                 job.setQueueRank(Integer.parseInt(value));
                             } catch (NumberFormatException nfe) {
                                 LOGGER.log(Level.WARNING, "Failed parsing job queue rank: " + nfe.getMessage(), nfe);
                                 job.setQueueRank(-1);
                             }
-                        } else if("queue_type".equals(key)) {
+                        } else if("queue_type".equalsIgnoreCase(key)) {
                             job.setQueueType(value);
-                        } else if("comment".equals(key)) {
+                        } else if("comment".equalsIgnoreCase(key)) {
                             job.setComment(value);
-                        } else if("submit_args".equals(key)) {
+                        } else if("submit_args".equalsIgnoreCase(key)) {
                             job.setSubmitArgs(value);
-                        } else if("submit_host".equals(key)) {
+                        } else if("submit_host".equalsIgnoreCase(key)) {
                             job.setSubmitHost(value);
-                        } else if("start_time".equals(key)) {
+                        } else if("start_time".equalsIgnoreCase(key)) {
                             job.setStartTime(value);
-                        } else if("start_count".equals(key)) {
+                        } else if("start_count".equalsIgnoreCase(key)) {
                             try {
                                 job.setStartCount(Integer.parseInt(value));
                             } catch (NumberFormatException nfe) {
                                 LOGGER.log(Level.WARNING, "Failed parsing job start count: " + nfe.getMessage(), nfe);
                                 job.setStartCount(-1);
                             }
-                        } else if("fault_tolerant".equals(key)) {
+                        } else if("fault_tolerant".equalsIgnoreCase(key)) {
                             job.setFaultTolerant(Boolean.parseBoolean(value));
-                        } else if("job_radix".equals(key)) {
+                        } else if("job_radix".equalsIgnoreCase(key)) {
                             try {
                                 job.setRadix(Integer.parseInt(value));
                             } catch (NumberFormatException nfe) {
                                 LOGGER.log(Level.WARNING, "Failed parsing job radix: " + nfe.getMessage(), nfe);
                                 job.setRadix(-1);
                             }
-                        } else if("walltime.remaining".equals(key)) { 
+                        } else if("walltime.remaining".equalsIgnoreCase(key)) { 
                             try {
                                 job.setWalltimeRemaining(Long.parseLong(value));
                             } catch (NumberFormatException nfe) {


### PR DESCRIPTION
Modified QStat Parser to make sure no path names were being cut off
(i.e. all "\n\t" are replaced with "").

submit_args=/bio/galazxy\n
\t/users/liccini
Before this would be parsed as:

submit_args=/bio/galaxy

After my modification:
submit_args=/bio/galaxy/users/liccini
